### PR TITLE
round gui size up

### DIFF
--- a/src/main/java/lv/mtm123/spigotutils/gui/GuiHolder.java
+++ b/src/main/java/lv/mtm123/spigotutils/gui/GuiHolder.java
@@ -15,7 +15,11 @@ public class GuiHolder implements InventoryHolder
     
     public GuiHolder(String title, int size) {
         this.title = title;
-        this.size = ((size % 9 == 0) ? size : 54);
+        if (54 <= size) {
+            this.size = 54;
+        } else {
+            this.size = ((size % 9 == 0) ? size : size/9+1);
+        }
         this.icons = new HashMap<>();
     }
     


### PR DESCRIPTION
rather than using default size 54 if size isn't valid you should round it up to the nearest multiple of 9 (Also there is no check for if the size is larger than 54